### PR TITLE
Fix interactive marker problem with gripper

### DIFF
--- a/prbt_pg70_support/config/pg70.srdf.xacro
+++ b/prbt_pg70_support/config/pg70.srdf.xacro
@@ -36,7 +36,7 @@ limitations under the License.
     <group name="gripper">
       <joint name="${prefix}gripper_finger_left_joint" />
     </group>
-    <end_effector group="gripper" name="pg70_end_effector" parent_link="${prefix}flange">
+    <end_effector group="gripper" name="pg70_end_effector" parent_link="${prefix}gripper_finger_left_link">
     </end_effector>
 
     <!--

--- a/prbt_pg70_support/config/pg70.srdf.xacro
+++ b/prbt_pg70_support/config/pg70.srdf.xacro
@@ -36,7 +36,7 @@ limitations under the License.
     <group name="gripper">
       <joint name="${prefix}gripper_finger_left_joint" />
     </group>
-    <end_effector group="gripper" name="pg70_end_effector" parent_link="${prefix}gripper_finger_left_link">
+    <end_effector group="gripper" name="pg70_end_effector" parent_link="${prefix}tcp">
     </end_effector>
 
     <!--


### PR DESCRIPTION
This pull request hopefully solves Issue #4.

I looked into this a little bit. [Here](https://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/urdf_srdf/urdf_srdf_tutorial.html#end-effectors) it is stated that there should be "no common links between the end-effector and the parent group it is connected to". Based on this statement and the [pg70.urdf.xacro, line 35](https://github.com/PilzDE/prbt_grippers/blob/3bbc438032d2930681ff5282aef541390bab6fb0/prbt_pg70_support/urdf/pg70.urdf.xacro#L35) I changed the parent link to: `"parent_link="${prefix}gripper_finger_left_link"`. This seems to work.

Any objections?