### PR TITLE
Move the include of gripper brackets to prbt_support

### DIFF
--- a/prbt_pg70_support/CHANGELOG.rst
+++ b/prbt_pg70_support/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package prbt_pg70_support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Omit definition of gripper brackets in pg70.urdf.xacro
+* Contributors: Pilz GmbH and Co. KG
+
 0.0.2 (2019-04-01)
 ------------------
 * Mark gripper as end_effector

--- a/prbt_pg70_support/urdf/pg70.urdf.xacro
+++ b/prbt_pg70_support/urdf/pg70.urdf.xacro
@@ -27,11 +27,4 @@ limitations under the License.
   <xacro:schunk_pg70 parent="$(arg robot_prefix)flange" name="$(arg gripper_name)" has_podest="false">
     <origin xyz="0 0 0.0171" rpy="0 0 ${-pi*3/4.}" />
   </xacro:schunk_pg70>
-
-  <!-- Add gripper brackets -->
-  <xacro:include filename="$(find prbt_support)/urdf/simple_gripper_brackets.urdf.xacro" />
-  <xacro:simple_gripper_brackets
-      gripper_name="$(arg gripper_name)"
-      parent_left="$(arg gripper_name)_finger_left_link"
-      parent_right="$(arg gripper_name)_finger_right_link"/>
 </gripper>


### PR DESCRIPTION
This allows the user to include custom brackets instead when he
includes the pg70 urdf in his application-urdf. Needs a change in https://github.com/PilzDE/pilz_robots as follow-up.

Targets #6.