### PR TITLE
Revert "Fix interactive marker problem with gripper"

### DIFF
--- a/prbt_pg70_support/config/pg70.srdf.xacro
+++ b/prbt_pg70_support/config/pg70.srdf.xacro
@@ -36,7 +36,7 @@ limitations under the License.
     <group name="gripper">
       <joint name="${prefix}gripper_finger_left_joint" />
     </group>
-    <end_effector group="gripper" name="pg70_end_effector" parent_link="${prefix}tcp">
+    <end_effector group="gripper" name="pg70_end_effector" parent_link="${prefix}flange">
     </end_effector>
 
     <!--


### PR DESCRIPTION
The current implementation gives a warning, so it was obviously the wrong solution:
```
[ WARN] [1555500360.498561910]: Could not identify parent group for end-effector 'pg70_end_effector'
```

A straight forward-solution for the interactive marker problem, is to specify its size (PilzDE/pilz_robots#108).

This PR Reverts PilzDE/prbt_grippers#5